### PR TITLE
/usr/local/cuda/... can be used for the latest version

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -1,2 +1,2 @@
 all:
-	nvcc -I/usr/local/cuda-10.0/samples/common/inc grayscale.cu `pkg-config --cflags --libs opencv4`
+	nvcc -I/usr/local/cuda/samples/common/inc grayscale.cu `pkg-config --cflags --libs opencv4`


### PR DESCRIPTION
The latest version f CUDA in JETSON series is 10.2, so anyway this Makefile cannot be used.